### PR TITLE
feat: customize instruction messages for the multi choice questions

### DIFF
--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -105,6 +105,7 @@ def checkbox(
 
         use_emacs_keys: Allow the user to select items from the list using
                         `Ctrl+N` (down) and `Ctrl+P` (up) keys.
+        instruction: A hint on how to navigate the menu.
 
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -38,6 +38,7 @@ def checkbox(
     use_arrow_keys: bool = True,
     use_jk_keys: bool = True,
     use_emacs_keys: bool = True,
+    instruction: Optional[str] = None,
     **kwargs: Any,
 ) -> Question:
     """Ask the user to select from a list of items.
@@ -164,15 +165,18 @@ def checkbox(
                     ("class:answer", "done ({} selections)".format(nbr_selected))
                 )
         else:
-            tokens.append(
-                (
-                    "class:instruction",
-                    "(Use arrow keys to move, "
-                    "<space> to select, "
-                    "<a> to toggle, "
-                    "<i> to invert)",
+            if instruction:
+                tokens.append(("class:instruction", instruction))
+            else:
+                tokens.append(
+                    (
+                        "class:instruction",
+                        "(Use arrow keys to move, "
+                        "<space> to select, "
+                        "<a> to toggle, "
+                        "<i> to invert)",
+                    )
                 )
-            )
         return tokens
 
     def get_selected_values() -> List[Any]:


### PR DESCRIPTION
**What is the problem that this PR addresses?**
There was a static instruction message for selectbox. Thanks to this PR, we now have a way to dynamically change the instruction message thanks to instruction argument.

example;
```python
questionary.checkbox(
   'Select toppings',
   choices=[
       "Cheese",
       "Tomato",
       "Pineapple",
   ],
   instruction="press <enter> to approve"
).ask()
```