### PR TITLE
Ia 222 implement skip question

### DIFF
--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -108,14 +108,20 @@ def checkbox(
 
         instruction: A message describing how to navigate the menu.
 
-        custom_key_binding: Dictionary of custom key bindings. The keys are either
-                            strings or `prompt_toolkit.keys.Keys` objects and the values are
-                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event.
-                            The following will exit the application with the result "custom" when the
-                            user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
-                            `{"c": lambda event: event.app.exit(result="custom")}` or
-                            `{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}`
-                            respectively.
+        custom_key_binding: A dictionary specifying custom key bindings for the prompt.
+                            The dictionary should have key-value pairs where the key represents
+                            the key combination or key code, and the value is a callable
+                            that will be executed when the key is pressed. The callable should
+                            take an `event` object as its argument, which provides
+                            information about the key event.
+
+                            Example usages:
+
+                            - Exit with result "custom" when the user presses "c":
+                                ``{"c": lambda event: event.app.exit(result="custom")}``
+
+                            - Exit with result "ctrl-q" when the user presses "ctrl-q":
+                                ``{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}``
 
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -38,6 +38,7 @@ def checkbox(
     use_jk_keys: bool = True,
     use_emacs_keys: bool = True,
     instruction: Optional[str] = None,
+    custom_key_binding: Optional[Dict[str | Keys, Callable]] = None,
     **kwargs: Any,
 ) -> Question:
     """Ask the user to select from a list of items.
@@ -104,8 +105,22 @@ def checkbox(
 
         use_emacs_keys: Allow the user to select items from the list using
                         `Ctrl+N` (down) and `Ctrl+P` (up) keys.
+        
         instruction: A message describing how to navigate the menu.
 
+        custom_key_binding: Dictionary of custom key bindings. The keys are either
+                            strings or `prompt_toolkit.keys.Keys` objects and the values are
+                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event
+
+                            Example:
+                                The following will exit the application with the result "custom" when the
+                                user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
+                                ```
+                                {
+                                    "c": lambda event: event.app.exit(result="custom"),
+                                    Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q"),
+                                }
+                                ```
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """
@@ -202,6 +217,9 @@ def checkbox(
     layout = common.create_inquirer_layout(ic, get_prompt_tokens, **kwargs)
 
     bindings = KeyBindings()
+    if custom_key_binding is not None:
+        for key, func in custom_key_binding.items():
+            bindings.add(key, eager=True)(func)
 
     @bindings.add(Keys.ControlQ, eager=True)
     @bindings.add(Keys.ControlC, eager=True)

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -110,17 +110,13 @@ def checkbox(
 
         custom_key_binding: Dictionary of custom key bindings. The keys are either
                             strings or `prompt_toolkit.keys.Keys` objects and the values are
-                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event
+                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event.
+                            The following will exit the application with the result "custom" when the
+                            user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
+                            `{"c": lambda event: event.app.exit(result="custom")}` or
+                            `{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}`
+                            respectively.
 
-                            Example:
-                                The following will exit the application with the result "custom" when the
-                                user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
-                                ```
-                                {
-                                    "c": lambda event: event.app.exit(result="custom"),
-                                    Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q"),
-                                }
-                                ```
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -38,7 +38,7 @@ def checkbox(
     use_jk_keys: bool = True,
     use_emacs_keys: bool = True,
     instruction: Optional[str] = None,
-    custom_key_binding: Optional[Dict[str | Keys, Callable]] = None,
+    custom_key_binding: Optional[Dict[Union[str, Keys], Callable]] = None,
     **kwargs: Any,
 ) -> Question:
     """Ask the user to select from a list of items.

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -105,7 +105,7 @@ def checkbox(
 
         use_emacs_keys: Allow the user to select items from the list using
                         `Ctrl+N` (down) and `Ctrl+P` (up) keys.
-        
+
         instruction: A message describing how to navigate the menu.
 
         custom_key_binding: Dictionary of custom key bindings. The keys are either

--- a/questionary/prompts/confirm.py
+++ b/questionary/prompts/confirm.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, Dict
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Optional
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import to_formatted_text
@@ -71,7 +74,7 @@ def confirm(
                     Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q"),
                 }
                 ```
-            
+
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using `.ask()`).
     """
@@ -122,8 +125,6 @@ def confirm(
         status["answer"] = True
         if auto_enter:
             exit_with_result(event)
-
-    
 
     @bindings.add(Keys.ControlH)
     def key_backspace(event):

--- a/questionary/prompts/confirm.py
+++ b/questionary/prompts/confirm.py
@@ -62,14 +62,20 @@ def confirm(
             accept their answer. If set to `True`, a valid input will be
             accepted without the need to press 'Enter'.
 
-        custom_key_binding: Dictionary of custom key bindings. The keys are either
-                            strings or `prompt_toolkit.keys.Keys` objects and the values are
-                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event.
-                            The following will exit the application with the result "custom" when the
-                            user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
-                            `{"c": lambda event: event.app.exit(result="custom")}` or
-                            `{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}`
-                            respectively.
+        custom_key_binding: A dictionary specifying custom key bindings for the prompt.
+                            The dictionary should have key-value pairs where the key represents
+                            the key combination or key code, and the value is a callable
+                            that will be executed when the key is pressed. The callable should
+                            take an `event` object as its argument, which provides
+                            information about the key event.
+
+                            Example usages:
+
+                            - Exit with result "custom" when the user presses "c":
+                                ``{"c": lambda event: event.app.exit(result="custom")}``
+
+                            - Exit with result "ctrl-q" when the user presses "ctrl-q":
+                                ``{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}``
 
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using `.ask()`).

--- a/questionary/prompts/confirm.py
+++ b/questionary/prompts/confirm.py
@@ -2,6 +2,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
+from typing import Union
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import to_formatted_text
@@ -24,7 +25,7 @@ def confirm(
     qmark: str = DEFAULT_QUESTION_PREFIX,
     style: Optional[Style] = None,
     auto_enter: bool = True,
-    custom_key_binding: Optional[Dict[str | Keys, Callable]] = None,
+    custom_key_binding: Optional[Dict[Union[str, Keys], Callable]] = None,
     **kwargs: Any,
 ) -> Question:
     """A yes or no question. The user can either confirm or deny.

--- a/questionary/prompts/confirm.py
+++ b/questionary/prompts/confirm.py
@@ -63,18 +63,13 @@ def confirm(
             accepted without the need to press 'Enter'.
 
         custom_key_binding: Dictionary of custom key bindings. The keys are either
-            strings or `prompt_toolkit.keys.Keys` objects and the values are
-            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event
-
-            Example:
-                The following will exit the application with the result "custom" when the
-                user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
-                ```
-                {
-                    "c": lambda event: event.app.exit(result="custom"),
-                    Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q"),
-                }
-                ```
+                            strings or `prompt_toolkit.keys.Keys` objects and the values are
+                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event.
+                            The following will exit the application with the result "custom" when the
+                            user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
+                            `{"c": lambda event: event.app.exit(result="custom")}` or
+                            `{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}`
+                            respectively.
 
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using `.ask()`).

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Sequence
@@ -36,6 +37,7 @@ def select(
     use_emacs_keys: bool = True,
     show_selected: bool = False,
     instruction: Optional[str] = None,
+    custom_key_binding: Optional[Dict[str | Keys, Callable]] = None,
     **kwargs: Any,
 ) -> Question:
     """A list of items to select **one** option from.
@@ -110,6 +112,18 @@ def select(
 
         show_selected: Display current selection choice at the bottom of list.
 
+        custom_key_binding: Dictionary of custom key bindings. The keys are either
+            strings or `prompt_toolkit.keys.Keys` objects and the values are
+            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event
+
+            Example:
+                The following will exit the application with the result "custom" when the
+                user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
+                ```
+                {
+                    "c": lambda event: event.app.exit(result="custom"),
+                    Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q"),
+                }
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """
@@ -185,6 +199,10 @@ def select(
     layout = common.create_inquirer_layout(ic, get_prompt_tokens, **kwargs)
 
     bindings = KeyBindings()
+
+    if custom_key_binding is not None:
+        for key, func in custom_key_binding.items():
+            bindings.add(key, eager=True)(func)
 
     @bindings.add(Keys.ControlQ, eager=True)
     @bindings.add(Keys.ControlC, eager=True)

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -112,14 +112,21 @@ def select(
 
         show_selected: Display current selection choice at the bottom of list.
 
-        custom_key_binding: Dictionary of custom key bindings. The keys are either
-                            strings or `prompt_toolkit.keys.Keys` objects and the values are
-                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event.
-                            The following will exit the application with the result "custom" when the
-                            user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
-                            `{"c": lambda event: event.app.exit(result="custom")}` or
-                            `{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}`
-                            respectively.
+        custom_key_binding: A dictionary specifying custom key bindings for the prompt.
+                            The dictionary should have key-value pairs where the key represents
+                            the key combination or key code, and the value is a callable
+                            that will be executed when the key is pressed. The callable should
+                            take an `event` object as its argument, which provides
+                            information about the key event.
+
+                            Example usages:
+
+                            - Exit with result "custom" when the user presses "c":
+                                ``{"c": lambda event: event.app.exit(result="custom")}``
+
+                            - Exit with result "ctrl-q" when the user presses "ctrl-q":
+                                ``{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}``
+
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -113,17 +113,13 @@ def select(
         show_selected: Display current selection choice at the bottom of list.
 
         custom_key_binding: Dictionary of custom key bindings. The keys are either
-            strings or `prompt_toolkit.keys.Keys` objects and the values are
-            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event
-
-            Example:
-                The following will exit the application with the result "custom" when the
-                user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
-                ```
-                {
-                    "c": lambda event: event.app.exit(result="custom"),
-                    Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q"),
-                }
+                            strings or `prompt_toolkit.keys.Keys` objects and the values are
+                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event.
+                            The following will exit the application with the result "custom" when the
+                            user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
+                            `{"c": lambda event: event.app.exit(result="custom")}` or
+                            `{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}`
+                            respectively.
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -37,7 +37,7 @@ def select(
     use_emacs_keys: bool = True,
     show_selected: bool = False,
     instruction: Optional[str] = None,
-    custom_key_binding: Optional[Dict[str | Keys, Callable]] = None,
+    custom_key_binding: Optional[Dict[Union[str, Keys], Callable]] = None,
     **kwargs: Any,
 ) -> Question:
     """A list of items to select **one** option from.

--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -1,17 +1,17 @@
 from typing import Any
+from typing import Callable
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Dict
-from typing import Callable
 
 from prompt_toolkit.document import Document
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
 from prompt_toolkit.lexers import Lexer
 from prompt_toolkit.lexers import SimpleLexer
-from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.shortcuts.prompt import PromptSession
 from prompt_toolkit.styles import Style
-from prompt_toolkit.keys import Keys
 
 from questionary.constants import DEFAULT_QUESTION_PREFIX
 from questionary.constants import INSTRUCTION_MULTILINE

--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 from prompt_toolkit.document import Document
 from prompt_toolkit.key_binding import KeyBindings
@@ -29,7 +30,7 @@ def text(
     multiline: bool = False,
     instruction: Optional[str] = None,
     lexer: Optional[Lexer] = None,
-    custom_key_binding: Optional[Dict[str | Keys, Callable]] = None,
+    custom_key_binding: Optional[Dict[Union[str, Keys], Callable]] = None,
     **kwargs: Any,
 ) -> Question:
     """Prompt the user to enter a free text message.

--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -76,14 +76,20 @@ def text(
         lexer: Supply a valid lexer to style the answer. Leave empty to
                use a simple one by default.
 
-        custom_key_binding: Dictionary of custom key bindings. The keys are either
-                            strings or `prompt_toolkit.keys.Keys` objects and the values are
-                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event.
-                            The following will exit the application with the result "custom" when the
-                            user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
-                            `{"c": lambda event: event.app.exit(result="custom")}` or
-                            `{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}`
-                            respectively.
+        custom_key_binding: A dictionary specifying custom key bindings for the prompt.
+                            The dictionary should have key-value pairs where the key represents
+                            the key combination or key code, and the value is a callable
+                            that will be executed when the key is pressed. The callable should
+                            take an `event` object as its argument, which provides
+                            information about the key event.
+
+                            Example usages:
+
+                            - Exit with result "custom" when the user presses "c":
+                                ``{"c": lambda event: event.app.exit(result="custom")}``
+
+                            - Exit with result "ctrl-q" when the user presses "ctrl-q":
+                                ``{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}``
 
         kwargs: Additional arguments, they will be passed to prompt toolkit.
 

--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -77,18 +77,13 @@ def text(
                use a simple one by default.
 
         custom_key_binding: Dictionary of custom key bindings. The keys are either
-            strings or `prompt_toolkit.keys.Keys` objects and the values are
-            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event
-
-            Example:
-                The following will exit the application with the result "custom" when the
-                user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
-                ```
-                {
-                    "c": lambda event: event.app.exit(result="custom"),
-                    Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q"),
-                }
-                ```
+                            strings or `prompt_toolkit.keys.Keys` objects and the values are
+                            callables that accept a `prompt_toolkit.key_binding.KeyBinding` event.
+                            The following will exit the application with the result "custom" when the
+                            user presses "c" and with the result "ctrl-q" when the user presses "ctrl-q"
+                            `{"c": lambda event: event.app.exit(result="custom")}` or
+                            `{Keys.ControlQ: lambda event: event.app.exit(result="ctrl-q")}`
+                            respectively.
 
         kwargs: Additional arguments, they will be passed to prompt toolkit.
 

--- a/tests/prompts/test_checkbox.py
+++ b/tests/prompts/test_checkbox.py
@@ -34,6 +34,20 @@ def test_select_with_instruction():
     assert result == ["foo"]
 
 
+def test_select_with_custom_key_bindings():
+    message = "Foo message"
+    kwargs = {
+        "choices": ["foo", "bar", "bazz"], 
+        "custom_key_binding": {
+            KeyInputs.ONE: lambda event: event.app.exit(result="1-pressed")
+        }
+    }
+    text = KeyInputs.ONE + "\r"
+
+    result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
+    assert result == "1-pressed"
+
+
 def test_select_first_choice_with_token_title():
     message = "Foo message"
     kwargs = {

--- a/tests/prompts/test_checkbox.py
+++ b/tests/prompts/test_checkbox.py
@@ -37,10 +37,10 @@ def test_select_with_instruction():
 def test_select_with_custom_key_bindings():
     message = "Foo message"
     kwargs = {
-        "choices": ["foo", "bar", "bazz"], 
+        "choices": ["foo", "bar", "bazz"],
         "custom_key_binding": {
             KeyInputs.ONE: lambda event: event.app.exit(result="1-pressed")
-        }
+        },
     }
     text = KeyInputs.ONE + "\r"
 

--- a/tests/prompts/test_confirm.py
+++ b/tests/prompts/test_confirm.py
@@ -102,5 +102,7 @@ def test_confirm_with_custom_key_bindings():
     }
     text = KeyInputs.ONE + "\r"
 
-    result, cli = feed_cli_with_input("confirm", message, text, auto_enter=False, **kwargs)
+    result, cli = feed_cli_with_input(
+        "confirm", message, text, auto_enter=False, **kwargs
+    )
     assert result == "1-pressed"

--- a/tests/prompts/test_confirm.py
+++ b/tests/prompts/test_confirm.py
@@ -91,3 +91,16 @@ def test_confirm_not_autoenter_backspace():
 
     result, cli = feed_cli_with_input("confirm", message, text, auto_enter=False)
     assert result is True
+
+
+def test_confirm_with_custom_key_bindings():
+    message = "Foo message"
+    kwargs = {
+        "custom_key_binding": {
+            KeyInputs.ONE: lambda event: event.app.exit(result="1-pressed")
+        }
+    }
+    text = KeyInputs.ONE + "\r"
+
+    result, cli = feed_cli_with_input("confirm", message, text, auto_enter=False, **kwargs)
+    assert result == "1-pressed"

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -103,6 +103,19 @@ def test_select_with_instruction():
     assert result == "foo"
 
 
+def test_select_with_custom_key_bindings():
+    message = "Foo message"
+    kwargs = {
+        "choices": ["foo", "bar", "bazz"], 
+        "custom_key_binding": {
+            KeyInputs.ONE: lambda event: event.app.exit(result="1-pressed")
+        }
+    }
+    text = KeyInputs.ONE + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "1-pressed"
+
 def test_cycle_to_first_choice():
     message = "Foo message"
     kwargs = {"choices": ["foo", "bar", "bazz"]}

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -106,15 +106,16 @@ def test_select_with_instruction():
 def test_select_with_custom_key_bindings():
     message = "Foo message"
     kwargs = {
-        "choices": ["foo", "bar", "bazz"], 
+        "choices": ["foo", "bar", "bazz"],
         "custom_key_binding": {
             KeyInputs.ONE: lambda event: event.app.exit(result="1-pressed")
-        }
+        },
     }
     text = KeyInputs.ONE + "\r"
 
     result, cli = feed_cli_with_input("select", message, text, **kwargs)
     assert result == "1-pressed"
+
 
 def test_cycle_to_first_choice():
     message = "Foo message"

--- a/tests/prompts/test_text.py
+++ b/tests/prompts/test_text.py
@@ -4,7 +4,8 @@ import re
 from prompt_toolkit.validation import ValidationError
 from prompt_toolkit.validation import Validator
 
-from tests.utils import KeyInputs, feed_cli_with_input
+from tests.utils import KeyInputs
+from tests.utils import feed_cli_with_input
 
 
 def test_legacy_name():
@@ -47,6 +48,7 @@ def test_text_with_custom_key_bindings():
 
     result, cli = feed_cli_with_input("text", message, text, **kwargs)
     assert result == "1-pressed"
+
 
 def test_text_validate_with_class():
     class SimpleValidator(Validator):

--- a/tests/prompts/test_text.py
+++ b/tests/prompts/test_text.py
@@ -4,7 +4,7 @@ import re
 from prompt_toolkit.validation import ValidationError
 from prompt_toolkit.validation import Validator
 
-from tests.utils import feed_cli_with_input
+from tests.utils import KeyInputs, feed_cli_with_input
 
 
 def test_legacy_name():
@@ -35,6 +35,18 @@ def test_text_validate():
     )
     assert result == "Doe"
 
+
+def test_text_with_custom_key_bindings():
+    message = "What is your name"
+    kwargs = {
+        "custom_key_binding": {
+            KeyInputs.ONE: lambda event: event.app.exit(result="1-pressed")
+        }
+    }
+    text = KeyInputs.ONE + "\r"
+
+    result, cli = feed_cli_with_input("text", message, text, **kwargs)
+    assert result == "1-pressed"
 
 def test_text_validate_with_class():
     class SimpleValidator(Validator):


### PR DESCRIPTION
**What is the problem that this PR addresses?**
Users were not able to customize keyboard inputs. Thanks to this PR, we can now customize the keyboard input as shown below thanks to new `custom_key_binding` argument. For now, `custom_key_binding` field has been added for `select`, `text`, `checkbox`, and `confirm`.

We will add a custom key handling for the `s` button in this example. Whenever user press `s`, we will return `_skipped_` string.`custom_key_binding` argument takes a dictionary where the key is either a string or `prompt_toolkit.keys.Keys` object the value is a callable that accepts a `prompt_toolkit.key_binding.KeyBinding` event.

```python
questionary.select(
    "What do you want to do?",
    choices=["Order a pizza", "Make a reservation", "Ask for opening hours"],
    instruction="(<s> to skip the question)",
    custom_key_binding= {
            "s": lambda event: event.app.exit(result="_skipped_")
        }
).ask()
```

or the same example can be written as

```python
def custom_handler(event):
     return event.app.exit(result="_skipped_")

questionary.select(
    "What do you want to do?",
    choices=["Order a pizza", "Make a reservation", "Ask for opening hours"],
    instruction="(<s> to skip the question)",
    custom_key_binding= {
            "s": custom_handler
        }
).ask()
```



**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
