### PR TITLE
feat: Add customized instruction support to confirm

### DIFF
--- a/questionary/prompts/confirm.py
+++ b/questionary/prompts/confirm.py
@@ -22,6 +22,7 @@ def confirm(
     qmark: str = DEFAULT_QUESTION_PREFIX,
     style: Optional[Style] = None,
     auto_enter: bool = True,
+    instruction: Optional[str] = None,
     **kwargs: Any,
 ) -> Question:
     """A yes or no question. The user can either confirm or deny.
@@ -58,6 +59,7 @@ def confirm(
             accept their answer. If set to `True`, a valid input will be
             accepted without the need to press 'Enter'.
 
+        instruction: A message describing how to navigate the menu.
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using `.ask()`).
     """
@@ -71,9 +73,11 @@ def confirm(
         tokens.append(("class:qmark", qmark))
         tokens.append(("class:question", " {} ".format(message)))
 
-        if not status["complete"]:
-            instruction = YES_OR_NO if default else NO_OR_YES
-            tokens.append(("class:instruction", "{} ".format(instruction)))
+        if instruction is not None:
+            tokens.append(("class:instruction", instruction))
+        elif not status["complete"]:
+            _instruction = YES_OR_NO if default else NO_OR_YES
+            tokens.append(("class:instruction", "{} ".format(_instruction)))
 
         if status["answer"] is not None:
             answer = YES if status["answer"] else NO

--- a/tests/prompts/test_confirm.py
+++ b/tests/prompts/test_confirm.py
@@ -91,3 +91,13 @@ def test_confirm_not_autoenter_backspace():
 
     result, cli = feed_cli_with_input("confirm", message, text, auto_enter=False)
     assert result is True
+
+
+def test_confirm_instruction():
+    message = "Foo message"
+    text = "Y" + "\r"
+
+    result, cli = feed_cli_with_input(
+        "confirm", message, text, instruction="Foo instruction"
+    )
+    assert result is True


### PR DESCRIPTION
**What is the problem that this PR addresses?**
There was a static instruction message for `confirm`. Thanks to this PR, we now have a way to dynamically change the instruction message thanks to `instruction` argument.

example;
```python
questionary.confirm("Are you amazed?", instruction="(<enter> or <y> to confirm, <no> to reject").ask()
```

...

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
